### PR TITLE
Correctly set task inputs and outputs to allow gradle to cache correctly

### DIFF
--- a/src/main/kotlin/org/sourcegrade/submitter/PrepareSubmissionTask.kt
+++ b/src/main/kotlin/org/sourcegrade/submitter/PrepareSubmissionTask.kt
@@ -20,8 +20,7 @@
 package org.sourcegrade.submitter
 
 import org.gradle.api.GradleException
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.getByType
@@ -29,11 +28,8 @@ import org.gradle.kotlin.dsl.getByType
 @Suppress("LeakingThis")
 abstract class PrepareSubmissionTask : Jar() {
 
-    @get:OutputDirectory
-    val mainResourcesFile = project.buildDir.resolve("resources/submit")
-
-    @get:Internal
-    val submissionInfoFile = mainResourcesFile.resolve("submission-info.json")
+    @get:InputFile
+    val submissionInfoFile = project.buildDir.resolve("resources/submit/submission-info.json")
 
     init {
         dependsOn("writeSubmissionInfo")

--- a/src/main/kotlin/org/sourcegrade/submitter/Submit.kt
+++ b/src/main/kotlin/org/sourcegrade/submitter/Submit.kt
@@ -40,4 +40,4 @@ internal data class SubmitExtensionImpl(
     override var requireTests: Boolean = true,
     override var requirePublicTests: Boolean = false,
     override var archiveExtension: String? = null,
-) : SubmitExtension
+) : SubmitExtension, java.io.Serializable

--- a/src/main/kotlin/org/sourcegrade/submitter/WriteSubmissionInfoTask.kt
+++ b/src/main/kotlin/org/sourcegrade/submitter/WriteSubmissionInfoTask.kt
@@ -22,8 +22,8 @@ package org.sourcegrade.submitter
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.getByType
@@ -31,11 +31,11 @@ import org.gradle.kotlin.dsl.getByType
 @Suppress("LeakingThis")
 abstract class WriteSubmissionInfoTask : DefaultTask() {
 
-    @get:OutputDirectory
-    val mainResourcesFile = project.buildDir.resolve("resources/submit")
+    @get:Input
+    val submitExtension: SubmitExtension = project.extensions.getByType()
 
-    @get:Internal
-    val submissionInfoFile = mainResourcesFile.resolve("submission-info.json")
+    @get:OutputFile
+    val submissionInfoFile = project.buildDir.resolve("resources/submit/submission-info.json")
 
     init {
         dependsOn("compileJava")
@@ -51,8 +51,7 @@ abstract class WriteSubmissionInfoTask : DefaultTask() {
 
     @TaskAction
     fun runTask() {
-        val submit = project.extensions.getByType<SubmitExtension>()
-        val submissionInfo = submit.toSubmissionInfo(
+        val submissionInfo = submitExtension.toSubmissionInfo(
             project.extensions.getByType<SourceSetContainer>().map { it.toInfo() })
         submissionInfoFile.apply {
             parentFile.mkdirs()


### PR DESCRIPTION
1. Correct `@get:Internal` -> `@get:OutputFile`/`@get:InputFile` on `submissionInfoFile` property 
2. Define the submit extension as a task input to `WriteSubmissionInfoTask` so that it is not cached even when part of the submit extension is changed.